### PR TITLE
Upgrade to netty 4.1.56.Final and netty-tcnative 2.0.35.Final

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,8 +6,8 @@ val releaseVersion = "21.1.0-SNAPSHOT"
 
 val libthriftVersion = "0.10.0"
 
-val defaultNetty4Version = "4.1.51.Final"
-val defaultNetty4StaticSslVersion = "2.0.34.Final"
+val defaultNetty4Version = "4.1.56.Final"
+val defaultNetty4StaticSslVersion = "2.0.35.Final"
 
 val useNettySnapshot: Boolean = sys.env.get("FINAGLE_USE_NETTY_4_SNAPSHOT") match {
   case Some(useSnapshot) => useSnapshot.toBoolean


### PR DESCRIPTION
Upgrade to netty 4.1.56.Final and netty-tcnative 2.0.35.Final for security fixes and AArch64 dependency rename.
The classifier for AArch64 was changed from linux-aarch64 to linux-aarch_64. This results in dependency problems with other projects.

https://netty.io/news/2020/12/17/4-1-55-Final.html
https://netty.io/news/2020/12/17/4-1-56-Final.html